### PR TITLE
Add support to write output to file

### DIFF
--- a/sandcastle.py
+++ b/sandcastle.py
@@ -21,23 +21,35 @@ parser.add_argument("-t", "--target", dest="targetStem",
                     help="Select a target stem name (e.g. 'shopify')", metavar="targetStem", required="True")
 parser.add_argument("-f", "--file", dest="inputFile",
                     help="Select a bucket permutation file (default: bucket-names.txt)", default="bucket-names.txt", metavar="inputFile")
-args = parser.parse_args()
+parser.add_argument("-o", "--output-file", dest="outputFile",
+                    help="File to write the command output", default=None, metavar="outputFile")
 
-with open(args.inputFile, 'r') as f: 
+args = parser.parse_args()
+with open(args.inputFile, 'r') as f:
     bucketNames = [line.strip() for line in f] 
     lineCount = len(bucketNames)
 
 print "[*] Commencing enumeration of '%s', reading %i lines from '%s'." % (args.targetStem, lineCount, f.name)
-
+output_file = None
 for name in bucketNames:
 	r = requests.head("http://%s%s.s3.amazonaws.com" % (args.targetStem, name))
 	if r.status_code != 404:
                 # macOS, coming soon: os.system("notify Potential match found! %s%s: %s" % (args.targetStem, name, r.status_code))
 		print "[+] Checking potential match: %s%s --> %s" % (args.targetStem, name, r.status_code)
 		check = commands.getoutput("/usr/local/bin/aws s3 ls s3://%s%s" % (args.targetStem, name))
-		print check
+		if args.outputFile is not None:
+			# will create the file if file not exists
+			output_file = open(args.outputFile, 'w')
+			output_file.write('Bucket Name --> %s%s' % (args.targetStem, name) + os.linesep)
+			output_file.write(check + os.linesep)
+		else:
+			print check
 	else:
 		sys.stdout.write('')
 
 print "[*] Enumeration of '%s' buckets complete." % (args.targetStem)
+# close the file if its open
+if output_file:
+	print "[*] Enumeration output written into file %s " % args.outputFile
+	output_file.close()
 # macOS, coming soon: os.system("notify Enumeration of %s buckets complete." % (args.targetStem))


### PR DESCRIPTION
I use sandcastle frequently and sometimes when multiple open buckets are found, then it becomes tough to scroll and search the terminal to get the list of files of all the buckets.
Hence, i thought to add the feature to write output to file optionally.